### PR TITLE
fix: bootstrap launcher development dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,22 @@ OpenAI Tunnel → standalone local MCP runtime
 
 ## Development
 
-Requirements: Windows, Codex CLI, a ChatGPT account with custom connectors, and an OpenAI Tunnel for MCP. The packaged launcher includes Bun; building from source requires Bun 1.3.14.
+Requirements: Windows, Codex CLI, a ChatGPT account with custom connectors, and an OpenAI Tunnel for MCP. The packaged launcher includes Bun; building from source requires Bun 1.3.14. On Windows, install that version with Bun's official PowerShell installer, then open a new PowerShell window and verify it is available:
+
+```powershell
+iex "& {$(irm https://bun.com/install.ps1)} -Version 1.3.14"
+bun --version
+```
+
+Clone the repository and use the root launcher bootstrap:
 
 ```powershell
 git clone https://github.com/m4j2rpf766-crypto/gpt-web-codex.git
 cd gpt-web-codex
-bun install --frozen-lockfile
-bun run launcher:dev
+bun run launcher
 ```
+
+The bootstrap installs both the root and `launcher/` dependencies with their frozen lockfiles before starting the Electron development launcher. Prefer this command over invoking `launcher/` directly. If `bun` is not recognized after installation, reopen PowerShell and confirm that Bun's install directory is on `PATH`.
 
 From the launcher:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -51,14 +51,22 @@ OpenAI Tunnel → 本机独立 MCP 运行时
 
 ## 本地开发
 
-当前需要 Windows、Codex CLI、支持自定义连接器的 ChatGPT 账户，以及用于 MCP 的 OpenAI Tunnel。安装包已经内置 Bun；从源码构建需要 Bun 1.3.14。
+当前需要 Windows、Codex CLI、支持自定义连接器的 ChatGPT 账户，以及用于 MCP 的 OpenAI Tunnel。安装包已经内置 Bun；从源码构建需要 Bun 1.3.14。Windows 可使用 Bun 官方 PowerShell 安装脚本安装指定版本，随后重新打开 PowerShell 并确认命令可用：
+
+```powershell
+iex "& {$(irm https://bun.com/install.ps1)} -Version 1.3.14"
+bun --version
+```
+
+克隆仓库后，使用根目录提供的 launcher bootstrap：
 
 ```powershell
 git clone https://github.com/m4j2rpf766-crypto/gpt-web-codex.git
 cd gpt-web-codex
-bun install --frozen-lockfile
-bun run launcher:dev
+bun run launcher
 ```
+
+该 bootstrap 会分别按 frozen lockfile 安装根目录和 `launcher/` 的依赖，再启动 Electron 开发版。建议使用这个入口，不要直接绕过它启动 `launcher/`。如果安装后仍提示无法识别 `bun`，请重新打开 PowerShell，并确认 Bun 的安装目录已经加入 `PATH`。
 
 在启动器中：
 

--- a/launcher/tests/packaging-contract.test.cjs
+++ b/launcher/tests/packaging-contract.test.cjs
@@ -11,6 +11,7 @@ const repositoryManifest = JSON.parse(fs.readFileSync(path.join(repositoryRoot, 
 test("the public launcher command uses the Electron bootstrap", () => {
   assert.equal(repositoryManifest.scripts.launcher, "bun run scripts/start-launcher.ts");
   assert.equal(repositoryManifest.scripts.launcher, repositoryManifest.scripts.app);
+  assert.equal(repositoryManifest.scripts["launcher:dev"], repositoryManifest.scripts.launcher);
 });
 
 test("launcher publishes native packages for all supported desktop operating systems", () => {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "app": "bun run scripts/start-launcher.ts",
     "app:package": "bun run --cwd launcher package",
     "app:smoke": "bun run --cwd launcher smoke:package",
-    "launcher:dev": "bun run --cwd launcher dev",
+    "launcher:dev": "bun run scripts/start-launcher.ts",
     "launcher:typecheck": "bun run --cwd launcher typecheck",
     "launcher:build": "bun run --cwd launcher build",
     "launcher:test": "bun run --cwd launcher test",


### PR DESCRIPTION
## Summary

- route the root `launcher:dev` command through the existing launcher bootstrap
- document the required Bun 1.3.14 setup and the recommended `bun run launcher` source-development path in both READMEs
- lock the public launcher commands to the bootstrap with a focused contract test

## Problem

The repository root and `launcher/` are separate Bun packages with separate manifests and lockfiles. A fresh root `bun install --frozen-lockfile` does not install the launcher's Vite/Electron dependencies, but the previous README immediately ran `bun run launcher:dev`, which entered `launcher/` directly. On a fresh Windows checkout this can fail with `Cannot find module 'vite/package.json'`.

The repository already has `scripts/start-launcher.ts`, which installs both dependency sets with frozen lockfiles before starting the development launcher. CI follows the same two-install model.

## Verification

- `bun run typecheck` — passed
- `bun run test` — 242 passed, 4 skipped, 0 failed
- `bun run launcher:typecheck` — passed
- `bun run launcher:test` — 78 passed, 1 skipped, 0 failed
- `bun run verify` — stopped at `bun audit` because the audit request returned HTTP 404; no project test/typecheck failure was reported before that external request failure